### PR TITLE
Use another method of trimming strings to avoid problems with multibyte chars

### DIFF
--- a/fixtures/01/example1.go
+++ b/fixtures/01/example1.go
@@ -25,3 +25,4 @@ func main() {
 //TODO: Multiline C1 (Line 24)
 //TODO: Multiline C2 (Line 25)
 //FIXME: Your attitude (Line 26)
+// todo тут какой-то очень-очень-очень-очень длинный комментарий про utf-8

--- a/godox.go
+++ b/godox.go
@@ -49,7 +49,7 @@ func getMessages(c *ast.Comment, fset *token.FileSet, keywords []string) []Messa
 				pos := fset.Position(c.Pos())
 				// trim the comment
 				if len(sComment) > 40 {
-					sComment = []byte(fmt.Sprintf("%s...", sComment[:40]))
+					sComment = []byte(fmt.Sprintf("%.40s...", sComment))
 				}
 				comments = append(comments, Message{
 					Pos: pos,

--- a/godox_test.go
+++ b/godox_test.go
@@ -25,6 +25,7 @@ func TestParse(t *testing.T) {
 				`fixtures/01/example1.go:25: Line contains TODO/BUG/FIXME: "TODO: Multiline C1 (Line 24)"`,
 				`fixtures/01/example1.go:26: Line contains TODO/BUG/FIXME: "TODO: Multiline C2 (Line 25)"`,
 				`fixtures/01/example1.go:27: Line contains TODO/BUG/FIXME: "FIXME: Your attitude (Line 26)"`,
+				`fixtures/01/example1.go:28: Line contains TODO/BUG/FIXME: "todo тут какой-то очень-очень-очень-очен..."`,
 				`fixtures/01/example2.go:5: Line contains TODO/BUG/FIXME: "TODO: Add JSON tag (Line 4)"`,
 				`fixtures/01/example2.go:6: Line contains TODO/BUG/FIXME: "toDO add more fields (Line 5)"`,
 				`fixtures/01/example2.go:12: Line contains TODO/BUG/FIXME: "TODO: multiline todo 1 (Line 11)"`,


### PR DESCRIPTION
Cutting byte array `sComment[:40]` may cause malformed utf-8 characters if string contain multibyte characters. Here, i fixed it