### PR TITLE
Fix ToDoc method issue

### DIFF
--- a/fixtures/00/example1.go
+++ b/fixtures/00/example1.go
@@ -1,0 +1,6 @@
+package main
+
+//TODO
+//...
+
+func main(){}

--- a/fixtures/04/example1.go
+++ b/fixtures/04/example1.go
@@ -1,0 +1,8 @@
+package main
+
+type foo struct{}
+
+// ToDoc method.
+func (f foo) ToDoc() int {
+	return 0
+}

--- a/godox.go
+++ b/godox.go
@@ -24,6 +24,7 @@ func getMessages(comment *ast.Comment, fset *token.FileSet, keywords []string) [
 	commentText := extractComment(comment.Text)
 
 	b := bufio.NewReader(bytes.NewBufferString(commentText))
+
 	var comments []Message
 
 	for lineNum := 0; ; lineNum++ {
@@ -31,10 +32,14 @@ func getMessages(comment *ast.Comment, fset *token.FileSet, keywords []string) [
 		if err != nil {
 			break
 		}
+
+		const minimumSize = 4
+
 		sComment := bytes.TrimSpace(line)
-		if len(sComment) < 4 {
+		if len(sComment) < minimumSize {
 			continue
 		}
+
 		for _, kw := range keywords {
 			if lkw := len(kw); !(bytes.EqualFold([]byte(kw), sComment[0:lkw]) &&
 				!hasAlphanumRuneAdjacent(sComment[lkw:])) {
@@ -47,6 +52,7 @@ func getMessages(comment *ast.Comment, fset *token.FileSet, keywords []string) [
 			if len(sComment) > commentLimit {
 				sComment = []byte(fmt.Sprintf("%.40s...", sComment))
 			}
+
 			comments = append(comments, Message{
 				Pos: pos,
 				Message: fmt.Sprintf(
@@ -61,6 +67,7 @@ func getMessages(comment *ast.Comment, fset *token.FileSet, keywords []string) [
 			break
 		}
 	}
+
 	return comments
 }
 
@@ -99,11 +106,14 @@ func Run(file *ast.File, fset *token.FileSet, keywords ...string) []Message {
 	if len(keywords) == 0 {
 		keywords = defaultKeywords
 	}
+
 	var messages []Message
+
 	for _, c := range file.Comments {
 		for _, ci := range c.List {
 			messages = append(messages, getMessages(ci, fset, keywords)...)
 		}
 	}
+
 	return messages
 }

--- a/godox.go
+++ b/godox.go
@@ -12,11 +12,9 @@ import (
 	"unicode/utf8"
 )
 
-var (
-	defaultKeywords = []string{"TODO", "BUG", "FIXME"}
-)
+var defaultKeywords = []string{"TODO", "BUG", "FIXME"}
 
-// Message contains a message and position
+// Message contains a message and position.
 type Message struct {
 	Pos     token.Position
 	Message string
@@ -76,7 +74,7 @@ func hasAlphanumRuneAdjacent(rest []byte) bool {
 		return false
 	}
 
-	switch rest[0] { //most common cases:
+	switch rest[0] { //most common cases
 	case ':', ' ', '(':
 		return false
 	}

--- a/godox_test.go
+++ b/godox_test.go
@@ -11,11 +11,12 @@ import (
 	"github.com/matoous/godox"
 )
 
-//nolint:funlen this is a unit test
+//nolint: funlen // this is a unit test
 func TestParse(t *testing.T) {
 	t.Parallel()
 
 	flag.Parse()
+
 	tests := []struct {
 		path         string
 		result       []string
@@ -68,8 +69,9 @@ func TestParse(t *testing.T) {
 			path: "./fixtures/04",
 		},
 	}
+
 	for _, tt := range tests {
-		tt := tt //nolint: varnamelen tt is ok on this context
+		tt := tt //nolint: varnamelen // tt is ok on this context
 		t.Run(tt.path, func(t *testing.T) {
 			t.Parallel()
 
@@ -79,12 +81,15 @@ func TestParse(t *testing.T) {
 				if info.IsDir() {
 					return nil
 				}
+
 				f, err := parser.ParseFile(fset, path, nil, parser.ParseComments)
 				if err != nil {
 					panic(err)
 				}
+
 				res := godox.Run(f, fset)
 				messages = append(messages, res...)
+
 				return nil
 			})
 

--- a/godox_test.go
+++ b/godox_test.go
@@ -18,6 +18,12 @@ func TestParse(t *testing.T) {
 		includeTests bool
 	}{
 		{
+			path: "./fixtures/00",
+			result: []string{
+				`fixtures/00/example1.go:3: Line contains TODO/BUG/FIXME: "TODO"`,
+			},
+		},
+		{
 			path: "./fixtures/01",
 			result: []string{
 				`fixtures/01/example1.go:14: Line contains TODO/BUG/FIXME: "TODO(fix): something (Line 13)"`,
@@ -54,6 +60,9 @@ func TestParse(t *testing.T) {
 				`fixtures/03/main.go:16: Line contains TODO/BUG/FIXME: "FIXME: Mutli line 3"`,
 			},
 		},
+		{
+			path: "./fixtures/04",
+		},
 	}
 	for _, tt := range tests {
 		tt := tt
@@ -73,12 +82,12 @@ func TestParse(t *testing.T) {
 				return nil
 			})
 
-			if len(messages) > len(tt.result) {
-				t.Error("should return less messages")
-			}
-
-			if len(messages) < len(tt.result) {
-				t.Error("should return more messages")
+			if a, b := len(messages), len(tt.result); b == 0 && a != b {
+				t.Errorf("should expect no messages, instead got:\n%q", messages)
+			} else if a > b {
+				t.Errorf("should return less messages (got %d, expects %d)", a, b)
+			} else if a < b {
+				t.Errorf("should return more messages (got %d, expect %d)", a, b)
 			}
 
 			for i := range tt.result {

--- a/godox_test.go
+++ b/godox_test.go
@@ -1,4 +1,4 @@
-package godox
+package godox_test
 
 import (
 	"flag"
@@ -7,6 +7,8 @@ import (
 	"os"
 	"path/filepath"
 	"testing"
+
+	"github.com/matoous/godox"
 )
 
 //nolint:funlen
@@ -67,7 +69,7 @@ func TestParse(t *testing.T) {
 	for _, tt := range tests {
 		tt := tt
 		t.Run(tt.path, func(t *testing.T) {
-			var messages []Message
+			var messages []godox.Message
 			_ = filepath.Walk(tt.path, func(path string, info os.FileInfo, _ error) error {
 				fset := token.NewFileSet()
 				if info.IsDir() {
@@ -77,7 +79,7 @@ func TestParse(t *testing.T) {
 				if err != nil {
 					panic(err)
 				}
-				res := Run(f, fset)
+				res := godox.Run(f, fset)
 				messages = append(messages, res...)
 				return nil
 			})

--- a/godox_test.go
+++ b/godox_test.go
@@ -11,7 +11,7 @@ import (
 	"github.com/matoous/godox"
 )
 
-//nolint: funlen // this is a unit test
+//nolint // reason this is a unit test
 func TestParse(t *testing.T) {
 	t.Parallel()
 
@@ -71,7 +71,7 @@ func TestParse(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		tt := tt //nolint: varnamelen // tt is ok on this context
+		tt := tt //nolint // reason tt is ok on this context
 		t.Run(tt.path, func(t *testing.T) {
 			t.Parallel()
 
@@ -93,11 +93,14 @@ func TestParse(t *testing.T) {
 				return nil
 			})
 
-			if a, b := len(messages), len(tt.result); b == 0 && a != b {
+			a, b := len(messages), len(tt.result)
+
+			switch {
+			case b == 0 && a != b:
 				t.Errorf("should expect no messages, instead got:\n%q", messages)
-			} else if a > b {
+			case a > b:
 				t.Errorf("should return less messages (got %d, expects %d)", a, b)
-			} else if a < b {
+			case a < b:
 				t.Errorf("should return more messages (got %d, expect %d)", a, b)
 			}
 

--- a/godox_test.go
+++ b/godox_test.go
@@ -11,7 +11,7 @@ import (
 	"github.com/matoous/godox"
 )
 
-//nolint:funlen
+//nolint:funlen this is a unit test
 func TestParse(t *testing.T) {
 	t.Parallel()
 
@@ -69,7 +69,7 @@ func TestParse(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
-		tt := tt //nolint: varnamelen
+		tt := tt //nolint: varnamelen tt is ok on this context
 		t.Run(tt.path, func(t *testing.T) {
 			t.Parallel()
 

--- a/godox_test.go
+++ b/godox_test.go
@@ -13,6 +13,8 @@ import (
 
 //nolint:funlen
 func TestParse(t *testing.T) {
+	t.Parallel()
+
 	flag.Parse()
 	tests := []struct {
 		path         string
@@ -67,8 +69,10 @@ func TestParse(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
-		tt := tt
+		tt := tt //nolint: varnamelen
 		t.Run(tt.path, func(t *testing.T) {
+			t.Parallel()
+
 			var messages []godox.Message
 			_ = filepath.Walk(tt.path, func(path string, info os.FileInfo, _ error) error {
 				fset := token.NewFileSet()


### PR DESCRIPTION
Hello

I recently find an odd case: I have a legacy code with one struct who contains the method `ToDoc`. I have a false positive on `gitlabci-lint` on the documentation of this method because `ToDoc` has a string `ToDo` in it.

I try to add the best solution with some fixtures

Enjoy