### PR TITLE
fix: 'File is not goimports-ed'

### DIFF
--- a/fixtures/01/example1.go
+++ b/fixtures/01/example1.go
@@ -3,8 +3,9 @@ package main
 
 import "fmt"
 
-//revive:disable
 // This comment is associated with the hello constant.x
+//
+//revive:disable
 const hello = "Hello, World!" // line comment 1
 
 // This comment is associated with the foo variable.


### PR DESCRIPTION
The PR fixes CI issue from https://github.com/matoous/godox/runs/20115780660:

<img width="869" alt="image" src="https://github.com/matoous/godox/assets/3228886/fb738489-c3cc-4008-9343-e78aa538ca55">
