### PR TITLE
all: Update workflow actions; set v1.55.2 as lint version

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,6 +1,6 @@
 name: Run linters
 
-on: [push]
+on: [push, pull_request]
 
 jobs:
   revive-lint:
@@ -8,10 +8,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout the code
-        uses: actions/checkout@v1
+        uses: actions/checkout@v4
 
       - name: Run Revive
-        uses: docker://morphy/revive-action:v1
+        uses: docker://morphy/revive-action:v2
         with:
           config: .revive.toml
         env:
@@ -22,10 +22,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out code into the Go module directory
-        uses: actions/checkout@v1
+        uses: actions/checkout@v4
       - name: Run GolangCI-Lint
-        uses: docker://matousdz/golangci-lint-action:v1.0.0
+        uses: golangci/golangci-lint-action@v3
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           config: .golangci.yml
+          version: v1.55.2

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,6 +1,6 @@
 name: Run tests
 
-on: [push]
+on: [push, pull_request]
 
 jobs:
   tests:
@@ -8,11 +8,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout the code
-        uses: actions/checkout@v1
+        uses: actions/checkout@v4
 
       - name: Run tests
-        uses: actions/setup-go@v1
+        uses: actions/setup-go@v5
         with:
-          go-version: '1.13'
+          go-version: '1.18'
 
-      - run: go test ./...
+      - run: go test -race -shuffle=on ./...

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,10 +1,4 @@
 linters-settings:
-  depguard:
-    list-type: blacklist
-    include-go-root: true
-    packages:
-      # we are using "github.com/json-iterator/go" instead of json encoder from stdlib
-      - "encoding/json"
   dupl:
     threshold: 100
   gocritic:
@@ -38,26 +32,36 @@ linters-settings:
 linters:
   enable-all: true
   disable:
+    - depguard
     # prealloc is not recommended by `golangci-lint` developers.
     - prealloc
     - gochecknoglobals
+
+    # deprecated
+    - maligned
+    - exhaustivestruct
+    - nosnakecase
+    - scopelint
+    - structcheck
+    - ifshort
+    - varcheck
+    - deadcode
+    - golint
+    - interfacer
 
 issues:
   exclude-rules:
     - path: _test\.go
       linters:
+        - exhaustruct
         - goconst
         - dupl
 
-    - path: fixtures
-      linters:
-        - gocritic
-        - varcheck
-        - deadcode
-        - unused
-
 run:
   modules-download-mode: readonly
+
+  skip-dirs:
+    - "fixtures"
 
 # output configuration options
 output:

--- a/.revive.toml
+++ b/.revive.toml
@@ -1,5 +1,6 @@
 ignoreGeneratedHeader = false
 severity = "warning"
+exclude = ["./fixtures/..."]
 
 # confidence <= 0.2 generate a lot of errors from package-comments rule. It marks files that do not contain
 # package-level comments as a warning irrespective of existing package-level coment in one file.

--- a/fixtures/01/example1.go
+++ b/fixtures/01/example1.go
@@ -3,9 +3,8 @@ package main
 
 import "fmt"
 
-// This comment is associated with the hello constant.x
-//
 //revive:disable
+// This comment is associated with the hello constant.x
 const hello = "Hello, World!" // line comment 1
 
 // This comment is associated with the foo variable.

--- a/godox.go
+++ b/godox.go
@@ -1,3 +1,5 @@
+// Package godox is a linter that scans Go code for comments containing certain keywords
+// (like TODO, BUG, FIXME) which typically indicate areas that require attention.
 package godox
 
 import (


### PR DESCRIPTION
This PR fixes CI. Changes:

- Run workflows on pull requests.
- Set Go 1.18 in CI (the same as in the `go.mod`).
- Update to the latest actions `checkout`, `revive-action`, `setup-go`, `golangci-lint-action`.
- Set latest version 1.55.2 for golangci-lint.
- Add options `-race -shuffle=on` for `go test`.
- Revert https://github.com/matoous/godox/pull/9.
- Fix `godox.go:1:1: should have a package comment`.