### PR TITLE
refactor: Simplify getMessages and extractComment

### DIFF
--- a/godox.go
+++ b/godox.go
@@ -25,19 +25,14 @@ type Message struct {
 func getMessages(comment *ast.Comment, fset *token.FileSet, keywords []string) []Message {
 	commentText := extractComment(comment.Text)
 
-	b := bufio.NewReader(bytes.NewBufferString(commentText))
+	scanner := bufio.NewScanner(bytes.NewBufferString(commentText))
 
 	var comments []Message
 
-	for lineNum := 0; ; lineNum++ {
-		line, _, err := b.ReadLine()
-		if err != nil {
-			break
-		}
-
+	for lineNum := 0; scanner.Scan(); lineNum++ {
 		const minimumSize = 4
 
-		sComment := bytes.TrimSpace(line)
+		sComment := bytes.TrimSpace(scanner.Bytes())
 		if len(sComment) < minimumSize {
 			continue
 		}
@@ -76,15 +71,12 @@ func getMessages(comment *ast.Comment, fset *token.FileSet, keywords []string) [
 func extractComment(commentText string) string {
 	switch commentText[1] {
 	case '/':
-		commentText = commentText[2:]
-		if len(commentText) > 0 && commentText[0] == ' ' {
-			commentText = commentText[1:]
-		}
+		return strings.TrimPrefix(commentText[2:], " ")
 	case '*':
-		commentText = commentText[2 : len(commentText)-2]
+		return commentText[2 : len(commentText)-2]
+	default:
+		return commentText
 	}
-
-	return commentText
 }
 
 func hasAlphanumRuneAdjacent(rest []byte) bool {


### PR DESCRIPTION
The PR simplifies implementation of `getMessages` by replacing `bufio.Reader` with `bufio.Scanner` for comment processing. Additionally, leverages `strings.TrimPrefix` to simplify `extractComment`.